### PR TITLE
dosbox 0.74-2

### DIFF
--- a/Formula/dosbox.rb
+++ b/Formula/dosbox.rb
@@ -1,9 +1,8 @@
 class Dosbox < Formula
   desc "DOS Emulator"
   homepage "https://www.dosbox.com/"
-  url "https://downloads.sourceforge.net/project/dosbox/dosbox/0.74/dosbox-0.74.tar.gz"
-  sha256 "13f74916e2d4002bad1978e55727f302ff6df3d9be2f9b0e271501bd0a938e05"
-  revision 1
+  url "https://downloads.sourceforge.net/project/dosbox/dosbox/0.74-2/dosbox-0.74-2.tar.gz"
+  sha256 "7077303595bedd7cd0bb94227fa9a6b5609e7c90a3e6523af11bc4afcb0a57cf"
 
   bottle do
     cellar :any
@@ -30,15 +29,6 @@ class Dosbox < Formula
 
   conflicts_with "dosbox-x", :because => "both install `dosbox` binaries"
 
-  # Fix compilation with Xcode 9
-  # https://sourceforge.net/p/dosbox/patches/274/
-  if DevelopmentTools.clang_build_version >= 900
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/9102536006/dosbox/xcode9.patch"
-      sha256 "a23a4cf691452e5d13e159063d9cd8b9bd508c4982116b471fd6fa72fc021eba"
-    end
-  end
-
   def install
     args = %W[
       --prefix=#{prefix}
@@ -48,24 +38,9 @@ class Dosbox < Formula
     ]
     args << "--enable-debug" if build.with? "debugger"
 
-    if build.head?
-      # Prevent unstable build with clang
-      # https://sourceforge.net/p/dosbox/code-0/3894/
-      ENV.O0
-    else
-      # Disable dynamic cpu core recompilation that crashes on 64-bit platform
-      # https://github.com/Homebrew/homebrew-games/issues/171
-      args << "--disable-dynrec"
-    end
-
     system "./autogen.sh" if build.head?
     system "./configure", *args
     system "make", "install"
-  end
-
-  def caveats; <<~EOS
-    DOSBox is not built for optimal performance due to unstability on 64-bit platform.
-  EOS
   end
 
   test do


### PR DESCRIPTION
Building 64-bit with clang and optimizations enabled is now
supported officially, so the formula can be substantially simplified.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
